### PR TITLE
Added list message for arg error message

### DIFF
--- a/me/anemys/commandapi/CommandBuilder.java
+++ b/me/anemys/commandapi/CommandBuilder.java
@@ -25,6 +25,7 @@ public class CommandBuilder {
     private int minArgs = 0;
     private int maxArgs = -1;
     private String argErrorMessage;
+    private List<String> argErrorMessageList = new ArrayList<>();
 
     /**
      *
@@ -135,6 +136,33 @@ public class CommandBuilder {
     }
 
     /**
+     * Sets a list of usage examples for the command.
+     *
+     * @param usageList The list of usage examples.
+     * @return The CommandBuilder instance.
+     */
+    public CommandBuilder argErrorMessageList(List<String> usageList) {
+        this.argErrorMessageList = usageList;
+        return this;
+    }
+
+    /**
+     * Sets the command usage examples from a varargs list.
+     *
+     * @param usage The usage examples.
+     * @return The CommandBuilder instance.
+     */
+    public CommandBuilder argErrorMessageList(String... usage) {
+        this.argErrorMessageList = Arrays.asList(usage);
+        return this;
+    }
+
+    // usageList getter method
+    public List<String> getArgErrorMessageList() {
+        return argErrorMessageList;
+    }
+
+    /**
      *
      * @param minArgs       The minimum number of arguments.
      * @param maxArgs       The maximum number of arguments.
@@ -148,6 +176,13 @@ public class CommandBuilder {
         return this;
     }
 
+    public CommandBuilder arguments(int minArgs, int maxArgs, List<String> errorMessages) {
+        this.minArgs = minArgs;
+        this.maxArgs = maxArgs;
+        this.argErrorMessageList = errorMessages;
+        return this;
+    }
+
     /**
      * Registers the command with the plugin.
      */
@@ -156,6 +191,7 @@ public class CommandBuilder {
         if (!aliases.isEmpty()) {
             executor.setAliases(aliases);
         }
+
         if (!description.isEmpty()) {
             executor.setDescription(description);
         }

--- a/me/anemys/commandapi/CommandExecutor.java
+++ b/me/anemys/commandapi/CommandExecutor.java
@@ -55,9 +55,17 @@ public class CommandExecutor extends Command {
         if (builder.getMinArgs() > 0 || builder.getMaxArgs() >= 0) {
             if (args.length < builder.getMinArgs() ||
                     (builder.getMaxArgs() >= 0 && args.length > builder.getMaxArgs())) {
+                if(builder.getArgErrorMessage() == null && builder.getArgErrorMessageList() != null && !builder.getArgErrorMessageList().isEmpty()) {
+                    for(String message : getArgErrorMessageList()) {
+                        sender.sendMessage(message);
+                    }
+                    return true;
+
+                }
                 sender.sendMessage(builder.getArgErrorMessage() != null ?
                         builder.getArgErrorMessage() :
                         "Invalid number of arguments! Usage: " + getUsage());
+
                 return true;
             }
         }
@@ -109,4 +117,12 @@ public class CommandExecutor extends Command {
         }
         return filteredCompletions;
     }
+
+    private List<String> getArgErrorMessageList() {
+        if (!builder.getArgErrorMessageList().isEmpty()) {
+            return builder.getArgErrorMessageList();
+        }
+        return Arrays.asList(builder.getArgErrorMessage() != null ? builder.getArgErrorMessage() : "Invalid arguments.");
+    }
+
 }


### PR DESCRIPTION
This pull request enhances the `CommandBuilder` and `CommandExecutor` classes by introducing support for multiple argument error messages and improving error handling. The changes make it easier to provide detailed feedback to users when command arguments are invalid.

### Enhancements to `CommandBuilder`:

* Added a new field `argErrorMessageList` to store multiple error messages for invalid arguments. (`CommandBuilder.java`, [me/anemys/commandapi/CommandBuilder.javaR28](diffhunk://#diff-cdf3879b0630fd5d406ed4a75ead589d9df707192a9c4f683d8dbe94a72119daR28))
* Introduced overloaded `argErrorMessageList` methods to set the error message list using either a `List<String>` or a varargs array. (`CommandBuilder.java`, [me/anemys/commandapi/CommandBuilder.javaR138-R164](diffhunk://#diff-cdf3879b0630fd5d406ed4a75ead589d9df707192a9c4f683d8dbe94a72119daR138-R164))
* Added a new `arguments` method to allow specifying a range of arguments along with a list of error messages. (`CommandBuilder.java`, [me/anemys/commandapi/CommandBuilder.javaR179-R185](diffhunk://#diff-cdf3879b0630fd5d406ed4a75ead589d9df707192a9c4f683d8dbe94a72119daR179-R185))

### Enhancements to `CommandExecutor`:

* Updated the `execute` method to send multiple error messages to the command sender if `argErrorMessageList` is provided and non-empty. (`CommandExecutor.java`, [me/anemys/commandapi/CommandExecutor.javaR58-R68](diffhunk://#diff-1a128e590a3eac49ca834e5cb746fe6f3c997649b1c887cd7e870813bac9f256R58-R68))
* Added a helper method `getArgErrorMessageList` to retrieve the appropriate error messages, falling back to a default message if none are set. (`CommandExecutor.java`, [me/anemys/commandapi/CommandExecutor.javaR120-R127](diffhunk://#diff-1a128e590a3eac49ca834e5cb746fe6f3c997649b1c887cd7e870813bac9f256R120-R127))

c o p i l o t    a c t i o n s